### PR TITLE
access token to access private compose-go dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
+    - name: Setup go mod
+      env:
+        TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      run: git config --global url."https://ndeloof:${TOKEN}@github.com".insteadOf "https://github.com"
+
     - name: Get dependencies
       run: go get -v -t -d ./...
 


### PR DESCRIPTION
**What I did**
Setup a personnal access token so we can pull compose-go dependency on CI

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/74225834-bf484000-4cbb-11ea-9e2f-ebf2018d23ce.png)
