### PR TITLE
Add a default network configuration for the project and use it for se…

### DIFF
--- a/compose-ref.go
+++ b/compose-ref.go
@@ -215,7 +215,7 @@ func createService(cli *client.Client, project string, prjDir string, s compose.
 	labels[internal.LabelConfig] = string(b)
 
 	fmt.Printf("Creating container for service %s ... ", s.Name)
-	networkMode := internal.NetworkMode(s, networks)
+	networkMode := internal.NetworkMode(project, s, networks)
 	mounts, err := internal.CreateContainerMounts(s, prjDir)
 	if err != nil {
 		return err


### PR DESCRIPTION
…rvice without network configuration

Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**What I did**
Fix the issue for compose file without any network configuration 

-  Add a default network
-  Attach service to this default network when no default configuration provided

Compose file example
```
version: "3.7"
services:
  test:
    image: nginx
    volumes:
      - ./main.go:/root/main.go
```

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/74339281-10336380-4da4-11ea-8c1e-55f4e0e480ba.png)
