### PR TITLE
compose-spec is public so we don't need GOPRIVATE anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@
 
 .DEFAULT_GOAL := help
 
-PACKAGE=github.com/compose-spec/compose-ref
 IMAGE_PREFIX=composespec/compose-ref-
 
 GOFLAGS=-mod=vendor
@@ -22,11 +21,11 @@ GOFLAGS=-mod=vendor
 .PHONY: build
 build: ## Build compose-ref binary
 	@mkdir -p bin/
-	GOPRIVATE=$(PACKAGE) GOFLAGS=$(GOFLAGS) go build -o bin/compose-ref compose-ref.go
+	GOFLAGS=$(GOFLAGS) go build -o bin/compose-ref compose-ref.go
 
 .PHONY: test
 test: ## Run tests
-	GOPRIVATE=$(PACKAGE) GOFLAGS=$(GOFLAGS) go test ./... -v
+	GOFLAGS=$(GOFLAGS) go test ./... -v
 
 .PHONY: fmt
 fmt: ## Format go files


### PR DESCRIPTION
**What I did**
Removed use of GOPRIVATE which is not required anymore

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/78879147-cb4e4500-7a53-11ea-8afe-f74573d41f1b.png)
